### PR TITLE
Add `ssh_check` task to allow sdr-deploy SSH checking to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It requires that the services to be run on a server be specified by a docker com
 
 ## Included Tasks
 * `ssh`: establishes an SSH connection to the host running in environment, and changes into the current deployment directory.
+* `ssh_check`: establishes an SSH connection to all app servers running prints environment information to confirm the connection was made. (This is used by sdr-deploy to check SSH connections can be made in bulk before proceeding with a mass deploy.)
 * `honeybadger:notify`: notifies Honeybadger of deploy using curl (thus, ruby is not required on host).
 * `docker:login`: log into Docker Hub. Logging in is required to avoid strict image download limits.
 * `docker:logout`: log out of Docker Hub.

--- a/lib/dlss/docker/capistrano/tasks/ssh_check.rake
+++ b/lib/dlss/docker/capistrano/tasks/ssh_check.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+desc 'check ssh connections to all app servers'
+task :ssh_check do
+  on roles(:app), in: :sequence do |host|
+    exec "ssh -l #{host.user} #{host.hostname} -p #{host.port || 22} -t 'env'"
+  end
+end


### PR DESCRIPTION
Help sdr-deploy's check-ssh command work again
